### PR TITLE
Move videoFrames to batch_folder

### DIFF
--- a/dd.py
+++ b/dd.py
@@ -2061,7 +2061,7 @@ def processBatch(pargs=None, folders=None, device=None, is_colab=False, session_
         logger.warning(f"Changing output size to {side_x}x{side_y}. Dimensions must by multiples of 64.")
 
     if pargs.animation_mode == "Video Input":
-        videoFramesFolder = f"videoFrames"
+        videoFramesFolder = f"{folders.batch_folder}/videoFrames"
         createPath(videoFramesFolder)
         logger.info(f"Exporting Video Frames (1 every {pargs.extract_nth_frame})...")
         pargs.max_frames = len(glob(f"{videoFramesFolder}/*.jpg"))


### PR DESCRIPTION
Currently, all Video Input animations will unpack their input video to the same `disco-diffusion-1/videoFrames` dir, which causes cross contamination for parallel runs, and that tends to be stored in the container ephemeral storage.

Move to batch_folder, so that it's stored with the project's output.